### PR TITLE
include directory install (issue 7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .sconf_temp
 .sconsign.dblite
 config.log
+build

--- a/SConstruct
+++ b/SConstruct
@@ -55,5 +55,6 @@ for t in targets:
 	SConscript(dirs = t, exports = ['env', 'platform',
 		'PKG_CONFIG', 'Prefix'], variant_dir = 'build/%s/%s' % (variant_dir, t), duplicate = 0)
 
-env.Install(Prefix + '/include', 'include/sonotopy')
+env.Install(Prefix + '/include/sonotopy', Glob('include/sonotopy/*.hpp'))
 env.Alias('install', Prefix)
+


### PR DESCRIPTION
it seems to be a scons bug with directory install targets. sconscript is changed to install headers directly.
