### PR TITLE
CCFLAGS merge moved

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -26,6 +26,12 @@ if platform  == 'posix':
 elif platform == 'darwin':
 	PKG_CONFIG = ARGUMENTS.get('PKGConfig', '/opt/local/bin/pkg-config')
 
+# architecture
+ARCH = ARGUMENTS.get('ARCH', 'i386')
+archflags = '-arch ' + ARCH
+env.Append(CCFLAGS = archflags)
+env.Append(LINKFLAGS = archflags)
+
 try:
 	env.MergeFlags(['!%s --cflags --libs fftw3' % PKG_CONFIG])
 except:

--- a/SConstruct
+++ b/SConstruct
@@ -26,12 +26,6 @@ if platform  == 'posix':
 elif platform == 'darwin':
 	PKG_CONFIG = ARGUMENTS.get('PKGConfig', '/opt/local/bin/pkg-config')
 
-# architecture
-ARCH = ARGUMENTS.get('ARCH', 'i386')
-archflags = '-arch ' + ARCH
-env.Append(CCFLAGS = archflags)
-env.Append(LINKFLAGS = archflags)
-
 try:
 	env.MergeFlags(['!%s --cflags --libs fftw3' % PKG_CONFIG])
 except:

--- a/SConstruct
+++ b/SConstruct
@@ -5,7 +5,6 @@ platform = env['PLATFORM']
 Prefix = ARGUMENTS.get('Prefix','/usr/local')
 
 env = Environment(CCFLAGS = '-Wall -pedantic -ffast-math -fPIC ')
-env.MergeFlags(ARGUMENTS.get('CCFLAGS', '').split())
 
 DEBUG = int(ARGUMENTS.get('DEBUG', '0'))
 if DEBUG:
@@ -16,6 +15,8 @@ env.Append(CCFLAGS = CCFLAGS)
 
 CPPPATH = ['include']
 env.Append(CPPPATH = CPPPATH)
+
+env.MergeFlags(ARGUMENTS.get('CCFLAGS', ''))
 
 LIBS = [["m", "math.h"],
 		["fftw3", "fftw3.h"]]


### PR DESCRIPTION
with the previous solution running scons CCFLAGS="-arch i386" caused strange errors on OS X 10.6, which are fixed if the merge is placed at the end, when the compilation parameters are ready.
